### PR TITLE
add  .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 config.py
+.DS_Store


### PR DESCRIPTION
Added .DS_Store file to gitignore list. This file is produced by macs and not necessary.